### PR TITLE
feat/refactor(BE): 로그인, 회원가입 등

### DIFF
--- a/FarmFarm_prj/FarmFarm_prj/settings.py
+++ b/FarmFarm_prj/FarmFarm_prj/settings.py
@@ -137,4 +137,6 @@ USE_TZ = True
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-AUTH_USER_MODEL = 'users.User' #사용자 모델 변경 
+
+# User Model
+AUTH_USER_MODEL = 'users.User' 

--- a/FarmFarm_prj/templates/base.html
+++ b/FarmFarm_prj/templates/base.html
@@ -9,9 +9,18 @@
     {% block content %}
     {% endblock %}
     <footer>
-        <a href="{% url 'users:onboarding' %}">
-            홈으로 돌아가기
-        </a>
+        <hr>
+        <a href="{% url 'users:onboarding' %}">홈</a> 
+        <!-- 개발용 로그인 상태 정보 표시 -->
+        {% if request.user.is_authenticated %}
+            <small>
+                [ 로그인됨: {{ request.user.username }} ({{ request.user.usertype }}) ]
+            </small>
+        {% else %}
+            <small>
+                [ 로그인되지 않음 ]
+            </small>
+        {% endif %}
     </footer>
 </body>
 </html>

--- a/FarmFarm_prj/users/fixtures/users.json
+++ b/FarmFarm_prj/users/fixtures/users.json
@@ -1,0 +1,38 @@
+[
+{
+  "model": "users.user",
+  "fields": {
+    "password": "pbkdf2_sha256$1000000$moIgCCVd9UQsiUbWbtYnTO$XIbwrCXL0ePJBFPZ/UZx52Yz2WjH3ycmnemg+VVAYNc=",
+    "last_login": "2025-08-11T04:24:48.197Z",
+    "is_superuser": false,
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": false,
+    "is_active": true,
+    "date_joined": "2025-08-08T15:01:46Z",
+    "username": "김OO",
+    "usertype": "BUYER",
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "users.user",
+  "fields": {
+    "password": "pbkdf2_sha256$1000000$7Q8n5FvzgBpxQcnJB4aK3D$jJX/1SCda8rMWrNK48AUiCSj/hHwXor2gAE/E2IsWwE=",
+    "last_login": "2025-08-11T04:21:24Z",
+    "is_superuser": false,
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": false,
+    "is_active": true,
+    "date_joined": "2025-08-08T15:02:36Z",
+    "username": "박OO",
+    "usertype": "SELLER",
+    "groups": [],
+    "user_permissions": []
+  }
+}
+]

--- a/FarmFarm_prj/users/forms.py
+++ b/FarmFarm_prj/users/forms.py
@@ -1,0 +1,15 @@
+from django import forms
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth import get_user_model
+
+class SignUpForm(UserCreationForm):
+    class Meta:
+        model = get_user_model()
+        fields = ('username', 'usertype', 'password1', 'password2')
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['username'].label = "사용자 이름"
+        self.fields['usertype'].label = "사용자 유형"
+        self.fields['password1'].label = "비밀번호"
+        self.fields['password2'].label = "비밀번호 확인"

--- a/FarmFarm_prj/users/templates/users/login.html
+++ b/FarmFarm_prj/users/templates/users/login.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    <h2>로그인</h2>
+    
+    <form method="post" action="{% url 'users:login' %}">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">로그인</button>
+    </form>
+
+    <p>아직 계정이 없으신가요? <a href="{% url 'users:signup' %}">회원가입</a></p>
+</body>
+</html>

--- a/FarmFarm_prj/users/templates/users/onboarding.html
+++ b/FarmFarm_prj/users/templates/users/onboarding.html
@@ -1,13 +1,36 @@
 {% extends "base.html" %}
 {% block content %}
 
-    <h2>당신은 무엇인가요?</h2>
+    {% if request.user.is_authenticated %}
 
-    <form action="{% url 'users:auto_login' %}" method="post">
-        {% csrf_token %}
-        <button type="submit" name="role" value="buyer">구매자 바로가기</button>
-        <button type="submit" name="role" value="seller">판매자 바로가기</button>
-    </form>
+        <h2>환영합니다, {{ request.user.usertype }} - {{ request.user.username }}님!</h2>
+        <a href="{% url 'users:logout' %}">로그아웃</a><br>
+
+        {% if request.user.usertype == 'BUYER' %}
+            <p>구매자 홈으로 이동: <a href="{% url 'users:buyer_home' %}">구매자 홈</a></p>
+        {% elif request.user.usertype == 'SELLER' %}
+            <p>판매자 홈으로 이동: <a href="{% url 'users:seller_home' %}">판매자 홈</a></p>
+        {% endif %}
+
+    {% else %}
+
+        <p>아직 로그인하지 않으셨나요? <a href="{% url 'users:login' %}">로그인</a></p>
+        <p>아직 회원이 아니신가요? <a href="{% url 'users:signup' %}">회원가입</a></p>
+
+        <hr>
+
+        <h2>페르소나로 자동 로그인하기</h2>
+        <h4>당신은 무엇인가요?</h4>
+            
+        <form action="{% url 'users:auto_login' %}" method="post">
+            {% csrf_token %}
+            <button type="submit" name="role" value="buyer">구매자 김OO 바로가기</button>
+            <button type="submit" name="role" value="seller">판매자 박OO 바로가기</button>
+        </form>
+
+        <br>
+
+    {% endif %}
 
 {% endblock %}
 

--- a/FarmFarm_prj/users/templates/users/signup.html
+++ b/FarmFarm_prj/users/templates/users/signup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    <h2>회원가입</h2>
+    <form method="post" action="{% url 'users:signup' %}">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">회원가입</button>
+    </form>
+    <p>이미 계정이 있으신가요? <a href="{% url 'users:login' %}">로그인</a></p>
+</body>
+</html>

--- a/FarmFarm_prj/users/urls.py
+++ b/FarmFarm_prj/users/urls.py
@@ -13,4 +13,7 @@ urlpatterns = [
     path('seller-step4/', seller_step4, name='seller_step4'),
     path('seller-step5/', seller_step5, name='seller_step5'),
     path('seller-home/', seller_home, name='seller_home'),
+    path('signup/', signup, name='signup'), # 개발용
+    path('login/', login, name='login'), # 개발용
+    path('logout/', logout, name='logout'), # 개발용
 ]

--- a/FarmFarm_prj/users/views.py
+++ b/FarmFarm_prj/users/views.py
@@ -2,29 +2,65 @@ from django.contrib.auth import authenticate, login
 from django.shortcuts import render, redirect
 from django.conf import settings
 from users.models import User 
+from users.forms import SignUpForm #개발용
+from django.contrib.auth.forms import AuthenticationForm #개발용
+from django.contrib.auth import login as auth_login  # 개발용 
+from django.contrib.auth import logout as auth_logout # 개발용
 from django.views.decorators.cache import never_cache # 뒤로가기 후 로그인했을 때 캐시 문제 해결
 
 @never_cache   
 def onboarding(request):
     return render(request, 'users/onboarding.html')
 
+#개발용 회원가입 
+def signup(request):
+    if request.method == 'GET':
+        form = SignUpForm()
+        return render(request, 'users/signup.html', {'form': form})
+    form = SignUpForm(request.POST)
+    
+    if form.is_valid():
+        user = form.save(commit=False)
+        user.set_password(form.cleaned_data['password1']) # 안전하게 암호화해서 저장
+        user.save()
+        return redirect('users:login')  # 회원가입 후 로그인 페이지로 이동
+    else:
+        return render(request, 'users/signup.html', {'form': form})  # 유효성 검사 실패 시 다시 폼 보여주기
+    
+#개발용 로그인
+def login(request):
+    if request.method == 'GET':
+        return render(request, 'users/login.html', {'form': AuthenticationForm()})
+    form = AuthenticationForm(request, request.POST)
+    if form.is_valid():
+        auth_login(request, form.user_cache) 
+        return redirect('users:onboarding')
+    return render(request, 'users/login.html', {'form': form})
+
+#개발용 로그아웃
+def logout(request):
+    if request.user.is_authenticated:
+        auth_logout(request)
+    return redirect('users:onboarding')  # 로그아웃 후 온보딩 페이지로 이동
+    
+
 def auto_login(request):
     if request.method == 'POST':
         role = request.POST.get('role')
         if role == 'buyer':
-            username = 'buyer'
+            username = '김OO'
             password = settings.BUYER_PASSWORD  
             user = authenticate(request, username=username, password=password)
             if user is not None:
-                login(request, user)
+                auth_login(request, user)
                 return redirect('users:buyer_home')  # 구매자 홈으로 이동
 
         elif role == 'seller':
-            username = 'seller'
+            username = '박OO'
             password = settings.SELLER_PASSWORD
             user = authenticate(request, username=username, password=password)
             if user is not None:
-                login(request, user)
+                auth_login(request, user)
                 return redirect('users:seller_step1')  # 구매자 온보딩 화면으로 이동 
 
     return redirect('users:onboarding')  # GET 요청 또는 실패 시 홈으로 이동


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #14 

## 📢 작업 내용 
> 개발용 로그인, 회원가입, 로그아웃 기능 추가

## ✨ Changes ,  📷 스크린샷 (선택)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/95a3f2e1-c33c-4d0c-bad4-c74c901cd169" />

- 온보딩 화면에서 회원가입/로그인 기능 추가
- 직접 회원가입 후 로그인 시,

<img width="300" alt="image" src="https://github.com/user-attachments/assets/3098ef1f-296f-4b4d-92a0-89372b0e147f" />

- (유저 타입) & (username) 나오도록 설정
- 유저 타입이 구매자이면 구매자 홈 화면으로 이동하도록 링크 설정
- 유저 타입이 판매자이면 판매자 홈 화면으로 이동하도록 링크 설정
- 로그인 상태를 지속적으로 보는게 편할 것 같아서 base.html에 footer로 로그인 정보가 뜨도록 설정해두었음 (+ 온보딩 화면으로 이동하는 링크도 항시 설정 해두었음)
- 페르소나 dumpdata 넣어둠 - 적용 방법은 리드미 참고 
- 페르소나 데이터가 적용되면, 페르소나 로그인 버튼 눌렀을 때 해당 계정으로 자동 로그인 되는 것 볼 수 있음 
  구매자 페르소나는 홈화면으로 바로 이동시켰음 (판매자는 판매자 절차 시작) 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/23c25bc5-0c4c-42eb-8f56-a306c7eac329" />
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/ac3ce1ec-40e6-4255-8cbd-24bba4802f44" />


## 💬 리뷰 요구사항 
- 판매자 페르소나 자동로그인 시 판매자 절차 생략하고 바로 홈으로 이동시키는 거 어떨까 고민
- 사업자 등록 과정이나 가게 정보 등록은 발표자료에 담는게 어떨까 싶음..! 
- 판매자 절차가 많아서 자동 로그인시킨 상태에서 절차를 수행하기에는 경우의 수가 너무 많아지고 뒤로가기 버튼이나 링크를 많이 달아야할 것으로 예상.. 
